### PR TITLE
Add support for specifying an owner

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 add_ssh_keys_from_github:
   usernames: []
+  owner: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 add_ssh_keys_from_github:
   usernames: []
-  owner: root
+  owner: "{{ansible_ssh_user}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
-- name: install httplib2
-  sudo: true
-  pip: name=httplib2
+#- name: install httplib2
+  #sudo: true
+  #pip: name=httplib2
 
 - name: get SSH keys from GitHub
   uri: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,15 +9,23 @@
   register: ssh_keys
   with_items: add_ssh_keys_from_github.usernames
 
-- name: add SSH key labels to ~/.ssh/authorized_keys
+- name: ensure /home/{{add_ssh_keys_from_github.owner}}/.ssh exists
+  file: dest="/home/{{add_ssh_keys_from_github.owner}}/.ssh" state=directory
+
+- name: ensure /home/{{add_ssh_keys_from_github.owner}}/.ssh/authorized_keys exists
+  action: >
+    command touch /home/{{add_ssh_keys_from_github.owner}}/.ssh/authorized_keys
+    creates=/home/{{add_ssh_keys_from_github.owner}}/.ssh/authorized_keys
+
+- name: add SSH key labels to /home/{{add_ssh_keys_from_github.owner}}/.ssh/authorized_keys
   lineinfile: >
-    dest=~/.ssh/authorized_keys
+    dest="/home/{{add_ssh_keys_from_github.owner}}/.ssh/authorized_keys"
     line="# {{ item }}"
   with_items: add_ssh_keys_from_github.usernames
 
-- name: add SSH keys to ~/.ssh/authorized_keys
+- name: add SSH keys to /home/{{add_ssh_keys_from_github.owner}}/.ssh/authorized_keys
   lineinfile: >
-    dest=~/.ssh/authorized_keys
+    dest="/home/{{add_ssh_keys_from_github.owner}}/.ssh/authorized_keys"
     line="{{ item.0.content }}"
     insertafter={{ item.1 }}
   with_together:


### PR DESCRIPTION
This allows for associating the key(s) to a different user from
ansible_ssh_user.

Signed-off-by: Jean-Denis Vauguet jd@vauguet.fr
